### PR TITLE
Transform version comparison function into a method on NSString

### DIFF
--- a/TDTChocolate.xcworkspace/contents.xcworkspacedata
+++ b/TDTChocolate.xcworkspace/contents.xcworkspacedata
@@ -119,10 +119,10 @@
             location = "group:NSArray+TDTRangeAdditions.m">
          </FileRef>
          <FileRef
-            location = "group:TDTVersionStringComparisons.h">
+            location = "group:NSString+TDTVersionComparison.h">
          </FileRef>
          <FileRef
-            location = "group:TDTVersionStringComparisons.m">
+            location = "group:NSString+TDTVersionComparison.m">
          </FileRef>
       </Group>
       <Group

--- a/TDTChocolate/FoundationAdditions/NSString+TDTVersionComparison.h
+++ b/TDTChocolate/FoundationAdditions/NSString+TDTVersionComparison.h
@@ -1,0 +1,16 @@
+#import <Foundation/Foundation.h>
+
+@interface NSString (TDTVersionComparison)
+
+/**
+ Compare the receiver with `string` after interpreting both of them as
+ strings representing "version"s.
+
+ Example of a version string: @"1.2.3.4-optional_label"
+
+ @pre The result is undefined if either the receiver or `string` does not
+      conform to the expected version format.
+ */
+- (NSComparisonResult)versionCompare:(NSString *)string;
+
+@end

--- a/TDTChocolate/FoundationAdditions/NSString+TDTVersionComparison.m
+++ b/TDTChocolate/FoundationAdditions/NSString+TDTVersionComparison.m
@@ -1,8 +1,10 @@
-#import "TDTVersionStringComparisons.h"
+#import "NSString+TDTVersionComparison.h"
 
-NSComparisonResult TDTCompareVersionStrings(NSString *v1, NSString *v2) {
-  NSArray *baseVersionFields = [v1 componentsSeparatedByString:@"."];
-  NSArray *newVersionFields = [v2 componentsSeparatedByString:@"."];
+@implementation NSString (TDTVersionComparison)
+
+- (NSComparisonResult)versionCompare:(NSString *)other {
+  NSArray *baseVersionFields = [self componentsSeparatedByString:@"."];
+  NSArray *newVersionFields = [other componentsSeparatedByString:@"."];
 
   NSUInteger minVersionFieldsCount = MIN([newVersionFields count], [baseVersionFields count]);
   for (NSUInteger index = 0; index < minVersionFieldsCount; index++) {
@@ -26,3 +28,5 @@ NSComparisonResult TDTCompareVersionStrings(NSString *v1, NSString *v2) {
     return NSOrderedSame;
   }
 }
+
+@end

--- a/TDTChocolate/FoundationAdditions/TDTVersionStringComparisons.h
+++ b/TDTChocolate/FoundationAdditions/TDTVersionStringComparisons.h
@@ -1,8 +1,0 @@
-#import <Foundation/Foundation.h>
-
-/**
- Compare two strings representing "version"s.
- 
- Example: 1.2.3.4-optional_label
- */
-NSComparisonResult TDTCompareVersionStrings(NSString *v1, NSString *v2);

--- a/TDTChocolate/TDTFoundationAdditions.h
+++ b/TDTChocolate/TDTFoundationAdditions.h
@@ -15,4 +15,4 @@
 #import "FoundationAdditions/NSProcessInfo+TDTEnvironmentDetection.h"
 #import "FoundationAdditions/TDTBlockAdditions.h"
 #import "FoundationAdditions/NSArray+TDTRangeAdditions.h"
-#import "FoundationAdditions/TDTVersionStringComparisons.h"
+#import "FoundationAdditions/NSString+TDTVersionComparison.h"

--- a/Tests/Tests/TDTVersionStringComparisonsTests.m
+++ b/Tests/Tests/TDTVersionStringComparisonsTests.m
@@ -1,5 +1,5 @@
 #import <XCTest/XCTest.h>
-#import <TDTChocolate/FoundationAdditions/TDTVersionStringComparisons.h>
+#import <TDTChocolate/FoundationAdditions/NSString+TDTVersionComparison.h>
 
 @interface TDTVersionStringComparisonsTests : XCTestCase
 
@@ -8,42 +8,42 @@
 @implementation TDTVersionStringComparisonsTests
 
 - (void)testCompareWithEqualVersion {
-  XCTAssertEqual(TDTCompareVersionStrings(@"1.0.0.2", @"1.0.0.2"), NSOrderedSame);
+  XCTAssertEqual([@"1.0.0.2" versionCompare:@"1.0.0.2"], NSOrderedSame);
 }
 
 - (void)testCompareWithLesserVersion {
-  XCTAssertEqual(TDTCompareVersionStrings(@"1.0.0.2", @"1.0.0.1"), NSOrderedDescending);
-  XCTAssertEqual(TDTCompareVersionStrings(@"2.10.0.6", @"2.9.1.32"), NSOrderedDescending);
+  XCTAssertEqual([@"1.0.0.2" versionCompare:@"1.0.0.1"], NSOrderedDescending);
+  XCTAssertEqual([@"2.10.0.6" versionCompare:@"2.9.1.32"], NSOrderedDescending);
 }
 
 - (void)testCompareWithLesserIncompleteVersion {
-  XCTAssertEqual(TDTCompareVersionStrings(@"1.0.0.2", @"1.0.0"), NSOrderedDescending);
+  XCTAssertEqual([@"1.0.0.2" versionCompare:@"1.0.0"], NSOrderedDescending);
 }
 
 - (void)testCompareWithGreaterVersion {
-  XCTAssertEqual(TDTCompareVersionStrings(@"1.0.0.2", @"1.0.3.1"), NSOrderedAscending);
+  XCTAssertEqual([@"1.0.0.2" versionCompare:@"1.0.3.1"], NSOrderedAscending);
 }
 
 - (void)testCompareWithGreaterIncompleteVersion {
-  XCTAssertEqual(TDTCompareVersionStrings(@"1.0.1.2", @"1.0.2"), NSOrderedAscending);
+  XCTAssertEqual([@"1.0.1.2" versionCompare:@"1.0.2"], NSOrderedAscending);
 }
 
 - (void)testCompareWithEqualVersionUsingIgnorableSeparator {
-  XCTAssertEqual(TDTCompareVersionStrings(@"1.0.1", @"1.0.1_foo"), NSOrderedSame);
-  XCTAssertEqual(TDTCompareVersionStrings(@"1.0.1", @"1.0.1-foo"), NSOrderedSame);
-  XCTAssertEqual(TDTCompareVersionStrings(@"1.0.1", @"1.0.1-foo_bar"), NSOrderedSame);
+  XCTAssertEqual([@"1.0.1" versionCompare:@"1.0.1_foo"], NSOrderedSame);
+  XCTAssertEqual([@"1.0.1" versionCompare:@"1.0.1-foo"], NSOrderedSame);
+  XCTAssertEqual([@"1.0.1" versionCompare:@"1.0.1-foo_bar"], NSOrderedSame);
 }
 
 - (void)testCompareWithLesserVersionUsingIgnorableSeparator {
-  XCTAssertEqual(TDTCompareVersionStrings(@"1.0.2", @"1.0.1_foo"), NSOrderedDescending);
-  XCTAssertEqual(TDTCompareVersionStrings(@"1.0.2", @"1.0.1-foo"), NSOrderedDescending);
-  XCTAssertEqual(TDTCompareVersionStrings(@"1.0.2", @"1.0.1-foo_bar"), NSOrderedDescending);
+  XCTAssertEqual([@"1.0.2" versionCompare:@"1.0.1_foo"], NSOrderedDescending);
+  XCTAssertEqual([@"1.0.2" versionCompare:@"1.0.1-foo"], NSOrderedDescending);
+  XCTAssertEqual([@"1.0.2" versionCompare:@"1.0.1-foo_bar"], NSOrderedDescending);
 }
 
 - (void)testCompareWithGreaterVersionUsingIgnorableSeparator {
-  XCTAssertEqual(TDTCompareVersionStrings(@"1.0.2", @"1.0.3_foo"), NSOrderedAscending);
-  XCTAssertEqual(TDTCompareVersionStrings(@"1.0.2", @"1.0.3-foo"), NSOrderedAscending);
-  XCTAssertEqual(TDTCompareVersionStrings(@"1.0.2", @"1.0.3-foo_bar"), NSOrderedAscending);
+  XCTAssertEqual([@"1.0.2" versionCompare:@"1.0.3_foo"], NSOrderedAscending);
+  XCTAssertEqual([@"1.0.2" versionCompare:@"1.0.3-foo"], NSOrderedAscending);
+  XCTAssertEqual([@"1.0.2" versionCompare:@"1.0.3-foo_bar"], NSOrderedAscending);
 }
 
 @end


### PR DESCRIPTION
I went with `versionCompare:` instead of `compareVersion:` because of the precedent set by `caseInsensitiveCompare`, `localizedCompare` etc.
