### PR TITLE
Add macros for conjuring up NSData from byte arrays

### DIFF
--- a/TDTChocolate.xcworkspace/contents.xcworkspacedata
+++ b/TDTChocolate.xcworkspace/contents.xcworkspacedata
@@ -136,6 +136,12 @@
          <FileRef
             location = "group:NSOperationQueue+TDTSerialQueueAdditions.m">
          </FileRef>
+         <FileRef
+            location = "group:TDTSizeofArray.h">
+         </FileRef>
+         <FileRef
+            location = "group:TDTNSDataFromByteArray.h">
+         </FileRef>
       </Group>
       <Group
          location = "group:TestingAdditions"

--- a/TDTChocolate/FoundationAdditions/TDTNSDataFromByteArray.h
+++ b/TDTChocolate/FoundationAdditions/TDTNSDataFromByteArray.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+#import "TDTSizeofArray.h"
+
+/**
+ @param BYTE_ARRAY a uint8_t byte array.
+ @return An `NSData` object initialized with bytes from `BYTE_ARRAY`
+ @pre The definition of `BYTE_ARRAY` must be in scope when this macro is evaluated.
+ */
+#define TDT_NSDATA_FROM_BYTE_ARRAY(BYTE_ARRAY) \
+  [NSData dataWithBytes:(BYTE_ARRAY) length:TDT_SIZEOF_ARRAY(BYTE_ARRAY)]

--- a/TDTChocolate/FoundationAdditions/TDTSizeofArray.h
+++ b/TDTChocolate/FoundationAdditions/TDTSizeofArray.h
@@ -1,0 +1,7 @@
+
+/**
+ @param C_ARRAY A C Array
+ @return The size of the `C_ARRAY
+ @pre The definition of `C_ARRAY` must be in scope when this macro is evaluated.
+ */
+#define TDT_SIZEOF_ARRAY(C_ARRAY) (sizeof(C_ARRAY) / sizeof((C_ARRAY)[0]))

--- a/TDTChocolate/TDTFoundationAdditions.h
+++ b/TDTChocolate/TDTFoundationAdditions.h
@@ -18,3 +18,5 @@
 #import "FoundationAdditions/NSString+TDTVersionComparison.h"
 #import "FoundationAdditions/NSMutableArray+TDTQueueing.h"
 #import "FoundationAdditions/NSOperationQueue+TDTSerialQueueAdditions.h"
+#import "FoundationAdditions/TDTSizeofArray.h"
+#import "FoundationAdditions/TDTNSDataFromByteArray.h"

--- a/Tests/TDTChocolateTests.xcodeproj/project.pbxproj
+++ b/Tests/TDTChocolateTests.xcodeproj/project.pbxproj
@@ -32,6 +32,10 @@
 		69C2DF141872D3BB0004C535 /* NSData_TDTAdditions_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 69C2DF121872D3BB0004C535 /* NSData_TDTAdditions_Tests.m */; };
 		69C2DF161872E0100004C535 /* NSString_TDTVersionComparison_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 69C2DF151872E0100004C535 /* NSString_TDTVersionComparison_Tests.m */; };
 		69C2DF171872E0100004C535 /* NSString_TDTVersionComparison_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 69C2DF151872E0100004C535 /* NSString_TDTVersionComparison_Tests.m */; };
+		69C4DB01187D419800BDB0C2 /* TDTSizeofArrayTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 69C0196D187D3AD400DFF308 /* TDTSizeofArrayTests.m */; };
+		69C4DB02187D419900BDB0C2 /* TDTSizeofArrayTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 69C0196D187D3AD400DFF308 /* TDTSizeofArrayTests.m */; };
+		69C4DB04187D448A00BDB0C2 /* TDTNSDataFromByteArrayTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 69C4DB03187D448A00BDB0C2 /* TDTNSDataFromByteArrayTests.m */; };
+		69C4DB05187D448A00BDB0C2 /* TDTNSDataFromByteArrayTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 69C4DB03187D448A00BDB0C2 /* TDTNSDataFromByteArrayTests.m */; };
 		69CB6FCA18517E63004D35DB /* NSArray_TDTFunctionalAdditions_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 69CB6FC918517E63004D35DB /* NSArray_TDTFunctionalAdditions_Tests.m */; };
 		69CB6FCB18517E63004D35DB /* NSArray_TDTFunctionalAdditions_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 69CB6FC918517E63004D35DB /* NSArray_TDTFunctionalAdditions_Tests.m */; };
 		69CB6FCD18517E78004D35DB /* NSSet_TDTFunctionalAdditions_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 69CB6FCC18517E78004D35DB /* NSSet_TDTFunctionalAdditions_Tests.m */; };
@@ -76,10 +80,12 @@
 		697F99751859D4F900DDF2A3 /* TDTBlockAdditionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDTBlockAdditionsTests.m; sourceTree = "<group>"; };
 		69C01967187D2DB400DFF308 /* NSMutableArray_TDTQueueing_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSMutableArray_TDTQueueing_Tests.m; sourceTree = "<group>"; };
 		69C0196A187D327400DFF308 /* NSOperationQueue_TDTSerialQueueAdditions_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSOperationQueue_TDTSerialQueueAdditions_Tests.m; sourceTree = "<group>"; };
+		69C0196D187D3AD400DFF308 /* TDTSizeofArrayTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDTSizeofArrayTests.m; sourceTree = "<group>"; };
 		69C2DEF31872935A0004C535 /* TDTNSStringExtendedComparisonTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDTNSStringExtendedComparisonTests.m; sourceTree = "<group>"; };
 		69C2DEF61872A62C0004C535 /* TDTLogErrorWarningHookTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDTLogErrorWarningHookTests.m; sourceTree = "<group>"; };
 		69C2DF121872D3BB0004C535 /* NSData_TDTAdditions_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSData_TDTAdditions_Tests.m; sourceTree = "<group>"; };
 		69C2DF151872E0100004C535 /* NSString_TDTVersionComparison_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSString_TDTVersionComparison_Tests.m; sourceTree = "<group>"; };
+		69C4DB03187D448A00BDB0C2 /* TDTNSDataFromByteArrayTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDTNSDataFromByteArrayTests.m; sourceTree = "<group>"; };
 		69CB6FC918517E63004D35DB /* NSArray_TDTFunctionalAdditions_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSArray_TDTFunctionalAdditions_Tests.m; sourceTree = "<group>"; };
 		69CB6FCC18517E78004D35DB /* NSSet_TDTFunctionalAdditions_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSSet_TDTFunctionalAdditions_Tests.m; sourceTree = "<group>"; };
 		69CB6FCF1851B57D004D35DB /* NSArray_TDTAdditions_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSArray_TDTAdditions_Tests.m; sourceTree = "<group>"; };
@@ -220,6 +226,8 @@
 				69C2DF151872E0100004C535 /* NSString_TDTVersionComparison_Tests.m */,
 				69C01967187D2DB400DFF308 /* NSMutableArray_TDTQueueing_Tests.m */,
 				69C0196A187D327400DFF308 /* NSOperationQueue_TDTSerialQueueAdditions_Tests.m */,
+				69C0196D187D3AD400DFF308 /* TDTSizeofArrayTests.m */,
+				69C4DB03187D448A00BDB0C2 /* TDTNSDataFromByteArrayTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -386,6 +394,7 @@
 			files = (
 				69ECAE431851CA63006C3176 /* NSDate_TDTComparisons_Tests.m in Sources */,
 				69ECAE461851D2AC006C3176 /* NSFileManager_TDTAdditions_Tests.m in Sources */,
+				69C4DB01187D419800BDB0C2 /* TDTSizeofArrayTests.m in Sources */,
 				69C2DEF71872A62C0004C535 /* TDTLogErrorWarningHookTests.m in Sources */,
 				69C01968187D2DB400DFF308 /* NSMutableArray_TDTQueueing_Tests.m in Sources */,
 				69C2DF161872E0100004C535 /* NSString_TDTVersionComparison_Tests.m in Sources */,
@@ -396,6 +405,7 @@
 				69E1C30D1850AF6B00E93E23 /* TDTObjectOrDefaultTests.m in Sources */,
 				697F99731859D1B600DDF2A3 /* TDTSmokeTests.m in Sources */,
 				69D1554C18601BC700D5B392 /* NSArray_TDTRangeAdditions_Tests.m in Sources */,
+				69C4DB04187D448A00BDB0C2 /* TDTNSDataFromByteArrayTests.m in Sources */,
 				6961BA84185B384900C6B2EF /* TDTUmbrellaHeaderTextualSanityTests.m in Sources */,
 				69C0196B187D327400DFF308 /* NSOperationQueue_TDTSerialQueueAdditions_Tests.m in Sources */,
 				69CB6FD41851B98F004D35DB /* NSString_TDTAdditions_Tests.m in Sources */,
@@ -411,6 +421,7 @@
 			files = (
 				69ECAE441851CA63006C3176 /* NSDate_TDTComparisons_Tests.m in Sources */,
 				69ECAE471851D2AC006C3176 /* NSFileManager_TDTAdditions_Tests.m in Sources */,
+				69C4DB02187D419900BDB0C2 /* TDTSizeofArrayTests.m in Sources */,
 				69C2DEF81872A62C0004C535 /* TDTLogErrorWarningHookTests.m in Sources */,
 				69C01969187D2DB400DFF308 /* NSMutableArray_TDTQueueing_Tests.m in Sources */,
 				69C2DF171872E0100004C535 /* NSString_TDTVersionComparison_Tests.m in Sources */,
@@ -421,6 +432,7 @@
 				69E1C30E1850AF6B00E93E23 /* TDTObjectOrDefaultTests.m in Sources */,
 				697F99741859D1B600DDF2A3 /* TDTSmokeTests.m in Sources */,
 				69D1554D18601BC700D5B392 /* NSArray_TDTRangeAdditions_Tests.m in Sources */,
+				69C4DB05187D448A00BDB0C2 /* TDTNSDataFromByteArrayTests.m in Sources */,
 				6961BA85185B384900C6B2EF /* TDTUmbrellaHeaderTextualSanityTests.m in Sources */,
 				69C0196C187D327400DFF308 /* NSOperationQueue_TDTSerialQueueAdditions_Tests.m in Sources */,
 				69CB6FD51851B98F004D35DB /* NSString_TDTAdditions_Tests.m in Sources */,

--- a/Tests/Tests/TDTNSDataFromByteArrayTests.m
+++ b/Tests/Tests/TDTNSDataFromByteArrayTests.m
@@ -1,0 +1,25 @@
+#import <XCTest/XCTest.h>
+#import <TDTChocolate/FoundationAdditions/TDTNSDataFromByteArray.h>
+
+@interface TDTNSDataFromByteArrayTests : XCTestCase
+
+@end
+
+@implementation TDTNSDataFromByteArrayTests
+
+- (void)testNSDataConstructionFromNonEmptyByteArray {
+  uint8_t bytes[] = { 0xab, 0xcd };
+  NSData *data = TDT_NSDATA_FROM_BYTE_ARRAY(bytes);
+  XCTAssertEqual(data.length, (NSUInteger)2);
+  const uint8_t *dataBytes = data.bytes;
+  XCTAssertEqual(dataBytes[0], bytes[0]);
+  XCTAssertEqual(dataBytes[1], bytes[1]);
+}
+
+- (void)testNSDataConstructionFromEmptyByteArray {
+  uint8_t bytes[] = { };
+  NSData *data = TDT_NSDATA_FROM_BYTE_ARRAY(bytes);
+  XCTAssertEqual(data.length, (NSUInteger)0);
+}
+
+@end

--- a/Tests/Tests/TDTSizeofArrayTests.m
+++ b/Tests/Tests/TDTSizeofArrayTests.m
@@ -1,0 +1,22 @@
+#import <XCTest/XCTest.h>
+#import <TDTChocolate/FoundationAdditions/TDTSizeofArray.h>
+
+@interface TDTSizeofArrayTests : XCTestCase
+
+@end
+
+@implementation TDTSizeofArrayTests
+
+- (void)testItReportsCorrectSizeOfANonEmptyArrayInScope {
+  char CArray[] = { 'a', 'b', 'c' };
+  size_t size = TDT_SIZEOF_ARRAY(CArray);
+  XCTAssertEqual(size, (size_t)3);
+}
+
+- (void)testItReportsCorrectSizeOfAnEmptyArrayInScope {
+  char CArray[] = { };
+  size_t size = TDT_SIZEOF_ARRAY(CArray);
+  XCTAssertEqual(size, (size_t)0);
+}
+
+@end


### PR DESCRIPTION
@chaitanyagupta need a second opinion.

The need for these arose in both iTalkto and Knock. 
