### PR TITLE
Remove unused string category for epoch conversion

### DIFF
--- a/TDTChocolate/FoundationAdditions/NSString+TDTAdditions.h
+++ b/TDTChocolate/FoundationAdditions/NSString+TDTAdditions.h
@@ -61,12 +61,4 @@
  */
 - (NSUInteger)unsignedIntegerValue;
 
-/**
- Interpret the receiver as the number of milliseconds since epoch.
-
- @warn If the string value cannot be interpreted as a number, then this method
-       will silently return an `NSDate` representing the epoch.
- */
-- (NSDate *)dateByInterpretingAsEpochMilliseconds;
-
 @end

--- a/TDTChocolate/FoundationAdditions/NSString+TDTAdditions.m
+++ b/TDTChocolate/FoundationAdditions/NSString+TDTAdditions.m
@@ -68,10 +68,4 @@
   return (NSUInteger)ul;
 }
 
-- (NSDate *)dateByInterpretingAsEpochMilliseconds {
-  long long millisecondsSinceEpoch = [self longLongValue];
-  NSTimeInterval secondsSinceEpoch = millisecondsSinceEpoch / 1000.0;
-  return [NSDate dateWithTimeIntervalSince1970:secondsSinceEpoch];
-}
-
 @end

--- a/Tests/Tests/NSString_TDTAdditions_Tests.m
+++ b/Tests/Tests/NSString_TDTAdditions_Tests.m
@@ -102,13 +102,4 @@
   XCTAssertEqual([outOfRangeNumberString unsignedIntegerValue], (NSUInteger)NSUIntegerMax);
 }
 
-- (void)testInterpretationOfEpochMilliseconds {
-  NSDate *date = [NSDate randomDate];
-  int64_t millisecondsSinceEpoch = [date millisecondsSinceEpoch];
-  NSString *string = [NSString stringWithFormat:@"%lld", millisecondsSinceEpoch];
-  NSDate *parsedDate = [string dateByInterpretingAsEpochMilliseconds];
-  int64_t millisecondsSinceEpochInParsedDate = [parsedDate millisecondsSinceEpoch];
-  XCTAssertEqual(millisecondsSinceEpoch, millisecondsSinceEpochInParsedDate);
-}
-
 @end


### PR DESCRIPTION
The implementation is off by 1 due to rounding. Rather than fix it, I'm removing it since it is unused as it is and can be resurrected if required.
