### PR TITLE
Annotate `TDTLog` as expecting format string

### DIFF
--- a/TDTChocolate/FoundationAdditions/TDTLog.h
+++ b/TDTChocolate/FoundationAdditions/TDTLog.h
@@ -65,4 +65,4 @@ TDTLog((@"VERBOSE %s #%d " format), __PRETTY_FUNCTION__, __LINE__, ## __VA_ARGS_
 /**
  Plain (but more performant) replacement for `NSLog`.
  */
-void TDTLog(NSString *format, ...);
+void TDTLog(NSString *format, ...) NS_FORMAT_FUNCTION(1, 2);

--- a/Tests/Tests/TDTSmokeTests.m
+++ b/Tests/Tests/TDTSmokeTests.m
@@ -11,6 +11,7 @@
 
 #import <XCTest/XCTest.h>
 #import <TDTChocolate/FoundationAdditions/TDTLog.h>
+#import <TDTChocolate/FoundationAdditions/TDTAssert.h>
 #import <TDTChocolate/FoundationAdditions/NSProcessInfo+TDTEnvironmentDetection.h>
 
 @interface TDTSmokeTests : XCTestCase
@@ -31,6 +32,16 @@
   // works only when called inside the main application bundle.
   // So we just make sure it does not crash.
   [[NSProcessInfo processInfo] tdt_isRunningTests];
+}
+
+- (void)testAssertionFormatStringArgumentsAreCheckedByTheCompiler {
+  // The following line should produce a warning.
+  TDTAssert(0, @"one: %@", 3);
+}
+
+- (void)testLogFormatStringArgumentsAreCheckedByTheCompiler {
+  // The following line should produce a warning.
+  TDTLog(@"one: %@", 3);
 }
 
 @end


### PR DESCRIPTION
This should prevent future issues like when Shilp did not come to know of an
incorrect format string in TDTKnock.
