### PR TITLE
Update README in light of the iOS Guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ then run
 
 and finally import the public header for the Foundation Additions subspec
 
-    #import <TDTChocolate/FoundationAdditions.h>
+    #import <TDTChocolate/TDTFoundationAdditions.h>
 
 ## Contributing
 


### PR DESCRIPTION
Assuming common knowledge based on https://github.com/talk-to/ios-guides/pull/3, the README can be simplified to remove documentation that is common across most repositories.
