### PR TITLE
Increase default timeout for async tests

### DIFF
--- a/TDTChocolate/TestingAdditions/NSRunLoop+TDTAsyncVerification.m
+++ b/TDTChocolate/TestingAdditions/NSRunLoop+TDTAsyncVerification.m
@@ -1,6 +1,6 @@
 #import "NSRunLoop+TDTAsyncVerification.h"
 
-const NSTimeInterval TDTAsyncVerificationTimeoutDefault = 0.1;
+const NSTimeInterval TDTAsyncVerificationTimeoutDefault = 2;
 static const NSTimeInterval TDTRunLoopInterval = 0.001;
 
 @implementation NSRunLoop (TDTAsyncVerification)


### PR DESCRIPTION
I've tested this locally with iTalkto -- the run time of the test
suite is not increased (as expected, because this timeout should
come into play only for failing tests).
