### PR TITLE
Avoid unstable API for debugger detection in Release builds

### DIFF
--- a/TDTChocolate/FoundationAdditions/NSProcessInfo+TDTEnvironmentDetection.h
+++ b/TDTChocolate/FoundationAdditions/NSProcessInfo+TDTEnvironmentDetection.h
@@ -30,11 +30,6 @@
  (and hence, everything logged by @p TDTLog) to a file. Usually, when
  a process is attached to a debugger, you do not want to redirect
  standard error.
-
- Source: Technical Q&A QA1361 "Detecting the Debugger"
-
- @note This method relies on a public but unstable Apple API. It
- should not be used in a release build.
  */
 - (BOOL)tdt_isDebugged;
 

--- a/TDTChocolate/FoundationAdditions/NSProcessInfo+TDTEnvironmentDetection.m
+++ b/TDTChocolate/FoundationAdditions/NSProcessInfo+TDTEnvironmentDetection.m
@@ -16,6 +16,20 @@ static NSString *const XCTestBundlePathExtension = @"xctest";
 }
 
 - (BOOL)tdt_isDebugged {
+#ifdef DEBUG
+  return [self tdt_isDebugged_UsingUnstableAPI];
+#else
+  return isatty(STDERR_FILENO);
+#endif
+}
+
+/**
+ Source: Technical Q&A QA1361 "Detecting the Debugger"
+
+ @note This method relies on a public but unstable Apple API. It
+ should not be used in a release build.
+ */
+- (BOOL)tdt_isDebugged_UsingUnstableAPI {
   int                 junk;
   int                 mib[4];
   struct kinfo_proc   info;


### PR DESCRIPTION
Note: Not an essential change. We can skip this if it feels like an unnecessary complication.
