### PR TITLE
Mention inter subspec dependencies

### DIFF
--- a/TDTChocolate.podspec
+++ b/TDTChocolate.podspec
@@ -22,11 +22,13 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'TestingAdditions' do |ss|
+    ss.dependency 'TDTChocolate/FoundationAdditions'
     ss.source_files = [ 'TDTChocolate/TestingAdditions/*.{h,m}',
                         'TDTChocolate/TDTTestingAdditions.h' ]
   end
 
   s.subspec 'CoreDataAdditions' do |ss|
+    ss.dependency 'TDTChocolate/FoundationAdditions'
     ss.source_files = [ 'TDTChocolate/CoreDataAdditions/*.{h,m}',
                         'TDTChocolate/TDTCoreDataAdditions.h' ]
     ss.frameworks = 'CoreData'


### PR DESCRIPTION
I faced this issue when trying to push the publish the pod to CocoaPods
-- the `pod trunk push` command started failing at the linting step.

From reading the docs
(http://www.rdoc.info/github/CocoaPods/Core/Pod/Specification/DSL:subspec) I
think this would be the missing link, but I'm not sure if this introduces any
other issues or not. FWIW,

```
pod spec lint TDTChocolate.podspec
```

works after this change. We'll know the behaviour of `pod trunk push` only
after we get this merged.
