### PR TITLE
Change custom assert to not require Foundation additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 2.5.?, 21-July-2014
 
   * Fix isSubsetOf to correctly compare mutable/immutable variants.
+  * Remove implicit dependency between Foundation and Testing additions.
 
 2.5.0, 21-July-2014
 

--- a/TDTChocolate/TestingAdditions/XCTAssert+TDTAdditions.h
+++ b/TDTChocolate/TestingAdditions/XCTAssert+TDTAdditions.h
@@ -14,10 +14,10 @@ XCTAssertTrue([(array) containsObject:(object)], @"Expected %@ to contain %@", (
  Assert that @p string contains @p substring
  */
 #define TDTXCTAssertContainsString(string, substring) \
-XCTAssertTrue([(string) tdt_containsString:(substring)], @"Expected %@ to contain %@", (string), (substring))
+XCTAssertTrue([(string) rangeOfString:(substring)].location != NSNotFound, @"Expected %@ to contain %@", (string), (substring))
 
 /**
  Assert that @p a is <= @p b.
  */
 #define TDTXCTAssertEarlierThanOrEqualToDate(a, b) \
-XCTAssertTrue([(a) tdt_isEarlierThanOrEqualToDate:(b)], @"Expected %@ to be earlier than or equal to %@", (a), (b))
+XCTAssertTrue([(a) compare:date] != NSOrderedDescending, @"Expected %@ to be earlier than or equal to %@", (a), (b))

--- a/Tests/TDTChocolateTests.xcodeproj/project.pbxproj
+++ b/Tests/TDTChocolateTests.xcodeproj/project.pbxproj
@@ -70,6 +70,8 @@
 		69CB6FD51851B98F004D35DB /* NSString_TDTAdditions_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 69CB6FD31851B98F004D35DB /* NSString_TDTAdditions_Tests.m */; };
 		69D1554C18601BC700D5B392 /* NSArray_TDTRangeAdditions_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 69D1554B18601BC700D5B392 /* NSArray_TDTRangeAdditions_Tests.m */; };
 		69D1554D18601BC700D5B392 /* NSArray_TDTRangeAdditions_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 69D1554B18601BC700D5B392 /* NSArray_TDTRangeAdditions_Tests.m */; };
+		69DD7BD8197D34AA004DFDDE /* XCTAssert_TDTAdditions_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 69DD7BD7197D34AA004DFDDE /* XCTAssert_TDTAdditions_Tests.m */; };
+		69DD7BD9197D34AF004DFDDE /* XCTAssert_TDTAdditions_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 69DD7BD7197D34AA004DFDDE /* XCTAssert_TDTAdditions_Tests.m */; };
 		69E1C30D1850AF6B00E93E23 /* TDTObjectOrDefaultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 69E1C30C1850AF6B00E93E23 /* TDTObjectOrDefaultTests.m */; };
 		69E1C30E1850AF6B00E93E23 /* TDTObjectOrDefaultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 69E1C30C1850AF6B00E93E23 /* TDTObjectOrDefaultTests.m */; };
 		69ECAE411851CA63006C3176 /* NSDate_TDTAdditions_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 69ECAE3E1851CA63006C3176 /* NSDate_TDTAdditions_Tests.m */; };
@@ -127,6 +129,7 @@
 		69CB6FCF1851B57D004D35DB /* NSArray_TDTAdditions_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSArray_TDTAdditions_Tests.m; sourceTree = "<group>"; };
 		69CB6FD31851B98F004D35DB /* NSString_TDTAdditions_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSString_TDTAdditions_Tests.m; sourceTree = "<group>"; };
 		69D1554B18601BC700D5B392 /* NSArray_TDTRangeAdditions_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSArray_TDTRangeAdditions_Tests.m; sourceTree = "<group>"; };
+		69DD7BD7197D34AA004DFDDE /* XCTAssert_TDTAdditions_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XCTAssert_TDTAdditions_Tests.m; sourceTree = "<group>"; };
 		69E1C30C1850AF6B00E93E23 /* TDTObjectOrDefaultTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDTObjectOrDefaultTests.m; sourceTree = "<group>"; };
 		69ECAE3E1851CA63006C3176 /* NSDate_TDTAdditions_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSDate_TDTAdditions_Tests.m; sourceTree = "<group>"; };
 		69ECAE401851CA63006C3176 /* NSDate_TDTComparisons_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSDate_TDTComparisons_Tests.m; sourceTree = "<group>"; };
@@ -278,6 +281,7 @@
 				690C09EC1940305B0005719D /* NSData_TDTAESDecryption_Tests.m */,
 				69027FAE196EADEE005A5057 /* NSURL_TDTQueryParameterEncoding_Tests.m */,
 				69027FB1196EB126005A5057 /* NSDictionary_TDTSubsetEquality_Tests.m */,
+				69DD7BD7197D34AA004DFDDE /* XCTAssert_TDTAdditions_Tests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -457,6 +461,7 @@
 				6958D1B4193C9BFA0005145D /* NSDictionary_TDTFunctionalAdditions_Tests.m in Sources */,
 				69ECAE411851CA63006C3176 /* NSDate_TDTAdditions_Tests.m in Sources */,
 				697F99761859D4F900DDF2A3 /* TDTBlockAdditionsTests.m in Sources */,
+				69DD7BD8197D34AA004DFDDE /* XCTAssert_TDTAdditions_Tests.m in Sources */,
 				69E1C30D1850AF6B00E93E23 /* TDTObjectOrDefaultTests.m in Sources */,
 				697F99731859D1B600DDF2A3 /* TDTSmokeTests.m in Sources */,
 				696E48C51934782400BD30A9 /* NSDictionary_TDTAdditions_Tests.m in Sources */,
@@ -496,6 +501,7 @@
 				6958D1B5193C9BFA0005145D /* NSDictionary_TDTFunctionalAdditions_Tests.m in Sources */,
 				69ECAE421851CA63006C3176 /* NSDate_TDTAdditions_Tests.m in Sources */,
 				697F99771859D4F900DDF2A3 /* TDTBlockAdditionsTests.m in Sources */,
+				69DD7BD9197D34AF004DFDDE /* XCTAssert_TDTAdditions_Tests.m in Sources */,
 				69E1C30E1850AF6B00E93E23 /* TDTObjectOrDefaultTests.m in Sources */,
 				697F99741859D1B600DDF2A3 /* TDTSmokeTests.m in Sources */,
 				696E48C61934782400BD30A9 /* NSDictionary_TDTAdditions_Tests.m in Sources */,

--- a/Tests/Tests/XCTAssert_TDTAdditions_Tests.m
+++ b/Tests/Tests/XCTAssert_TDTAdditions_Tests.m
@@ -1,0 +1,24 @@
+#import <XCTest/XCTest.h>
+#import <TDTChocolate/TDTTestingAdditions.h>
+
+@interface XCTAssert_TDTAdditions_Tests : XCTestCase
+
+@end
+
+@implementation XCTAssert_TDTAdditions_Tests
+
+- (void)testArrayContainmentAssert {
+  NSArray *receiver = @[@"x", @"y", @"z"];
+  TDTXCTAssertContains(receiver, @"y");
+}
+
+- (void)testStringContainmentAssert {
+  TDTXCTAssertContainsString(@"abc", @"b");
+}
+
+- (void)testDateEarlierThanOrEqualToAssert {
+  NSDate *date = [NSDate date];
+  TDTXCTAssertEarlierThanOrEqualToDate(date, [NSDate date]);
+}
+
+@end


### PR DESCRIPTION
See https://github.com/talk-to/Chocolate/pull/49 for why we want to avoid this
dependency.
