### PR TITLE
Fix local variable name in macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2.5.?, 22-July-2014
+
+  * Fix variable name in macro.
+
 2.5.1, 22-July-2014
 
   * Fix isSubsetOf to correctly compare mutable/immutable variants.

--- a/TDTChocolate/TestingAdditions/XCTAssert+TDTAdditions.h
+++ b/TDTChocolate/TestingAdditions/XCTAssert+TDTAdditions.h
@@ -20,4 +20,4 @@ XCTAssertTrue([(string) rangeOfString:(substring)].location != NSNotFound, @"Exp
  Assert that @p a is <= @p b.
  */
 #define TDTXCTAssertEarlierThanOrEqualToDate(a, b) \
-XCTAssertTrue([(a) compare:date] != NSOrderedDescending, @"Expected %@ to be earlier than or equal to %@", (a), (b))
+XCTAssertTrue([(a) compare:(b)] != NSOrderedDescending, @"Expected %@ to be earlier than or equal to %@", (a), (b))


### PR DESCRIPTION
The variable used in the test had the same name as the one in the macro,
so this was not caught until I started using it in Hush.
