### PR TITLE
Percent escape more characters in URL encoding

### DIFF
--- a/TDTChocolate/FoundationAdditions/NSURL+TDTQueryParameterEncoding.m
+++ b/TDTChocolate/FoundationAdditions/NSURL+TDTQueryParameterEncoding.m
@@ -12,7 +12,7 @@
 @implementation NSString (TDTQueryParameterEncoding)
 
 - (NSString *)tdt_stringByEncodingQueryParameter {
-  NSString *charactersToEscape = @"!*'();:@&=+$,/?%#[]\" |";
+  NSString *charactersToEscape = @"!*'();:@&=+$,/?%#[]\" |<>{}`^~\\";
   NSCharacterSet *allowedCharacters = [[NSCharacterSet characterSetWithCharactersInString:charactersToEscape] invertedSet];
   return [self stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
 }


### PR DESCRIPTION
Additional chars to percent-escape while forming URL with query params:
< > { } ` ^ ~ \